### PR TITLE
Fix ONNX initialization in browser

### DIFF
--- a/vite.onnx.plugin.ts
+++ b/vite.onnx.plugin.ts
@@ -27,11 +27,6 @@ export function onnxPlugin(): Plugin {
       return {
         optimizeDeps: {
           exclude: ['onnxruntime-web']
-        },
-        resolve: {
-          alias: {
-            'onnxruntime-web': resolve(__dirname, 'node_modules/onnxruntime-web/dist/ort.all.min.js')
-          }
         }
       };
     }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -5,9 +5,6 @@ import CopyPlugin from 'copy-webpack-plugin';
 const config: webpack.Configuration = {
   // ... existing config ...
   resolve: {
-    alias: {
-      'onnxruntime-web': path.resolve(__dirname, 'node_modules/onnxruntime-web/dist/ort.all.bundle.min.js'),
-    },
     extensions: ['.tsx', '.ts', '.js'],
   },
   plugins: [


### PR DESCRIPTION
## Summary
- remove custom aliases for `onnxruntime-web` from build configs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*