### PR TITLE
Fix vertical offset for mask overlay

### DIFF
--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -177,9 +177,10 @@ export default function ImageCanvas({ imageUrl, selectedColor }: ImageCanvasProp
     }
 
     const rect = canvas.getBoundingClientRect();
-    const scale = canvas.width / rect.width;
-    const x = Math.round((e.clientX - rect.left) * scale);
-    const y = Math.round((e.clientY - rect.top) * scale);
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const x = Math.round((e.clientX - rect.left) * scaleX);
+    const y = Math.round((e.clientY - rect.top) * scaleY);
     const clampedX = Math.min(Math.max(x, 0), canvas.width - 1);
     const clampedY = Math.min(Math.max(y, 0), canvas.height - 1);
 
@@ -251,9 +252,10 @@ export default function ImageCanvas({ imageUrl, selectedColor }: ImageCanvasProp
 
     try {
       const rect = canvas.getBoundingClientRect();
-      const scale = canvas.width / rect.width;
-      const x = Math.round((e.clientX - rect.left) * scale);
-      const y = Math.round((e.clientY - rect.top) * scale);
+      const scaleX = canvas.width / rect.width;
+      const scaleY = canvas.height / rect.height;
+      const x = Math.round((e.clientX - rect.left) * scaleX);
+      const y = Math.round((e.clientY - rect.top) * scaleY);
 
       const clampedX = Math.min(Math.max(x, 0), canvas.width - 1);
       const clampedY = Math.min(Math.max(y, 0), canvas.height - 1);


### PR DESCRIPTION
## Summary
- correct pointer coordinate scaling in `ImageCanvas`

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run test` *(fails: Missing script)*