### PR TITLE
Fix canvas mask overlay y-offset

### DIFF
--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -179,8 +179,8 @@ export default function ImageCanvas({ imageUrl, selectedColor }: ImageCanvasProp
     const rect = canvas.getBoundingClientRect();
     const scaleX = canvas.width / rect.width;
     const scaleY = canvas.height / rect.height;
-    const x = Math.round((e.clientX - rect.left) * scaleX);
-    const y = Math.round((e.clientY - rect.top) * scaleY);
+    const x = Math.round(e.nativeEvent.offsetX * scaleX);
+    const y = Math.round(e.nativeEvent.offsetY * scaleY);
     const clampedX = Math.min(Math.max(x, 0), canvas.width - 1);
     const clampedY = Math.min(Math.max(y, 0), canvas.height - 1);
 
@@ -254,8 +254,8 @@ export default function ImageCanvas({ imageUrl, selectedColor }: ImageCanvasProp
       const rect = canvas.getBoundingClientRect();
       const scaleX = canvas.width / rect.width;
       const scaleY = canvas.height / rect.height;
-      const x = Math.round((e.clientX - rect.left) * scaleX);
-      const y = Math.round((e.clientY - rect.top) * scaleY);
+      const x = Math.round(e.nativeEvent.offsetX * scaleX);
+      const y = Math.round(e.nativeEvent.offsetY * scaleY);
 
       const clampedX = Math.min(Math.max(x, 0), canvas.width - 1);
       const clampedY = Math.min(Math.max(y, 0), canvas.height - 1);

--- a/src/lib/sam/index.ts
+++ b/src/lib/sam/index.ts
@@ -259,11 +259,12 @@ export class SAM2 {
   }
 
   private restoreMaskToOriginal(mask: ImageData): ImageData {
-    const maskScale = mask.width / 1024;
-    const cropX = Math.round(this.offsetX * maskScale);
-    const cropY = Math.round(this.offsetY * maskScale);
-    const cropW = Math.round(this.origWidth * this.scale * maskScale);
-    const cropH = Math.round(this.origHeight * this.scale * maskScale);
+    const maskScaleX = mask.width / 1024;
+    const maskScaleY = mask.height / 1024;
+    const cropX = Math.round(this.offsetX * maskScaleX);
+    const cropY = Math.round(this.offsetY * maskScaleY);
+    const cropW = Math.round(this.origWidth * this.scale * maskScaleX);
+    const cropH = Math.round(this.origHeight * this.scale * maskScaleY);
 
     const srcCanvas = document.createElement('canvas');
     srcCanvas.width = mask.width;


### PR DESCRIPTION
## Summary
- separate horizontal and vertical mask scaling when restoring to original size

## Testing
- `npm run lint`
- `npm run build`
