### PR TITLE
Enhance surface controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -395,3 +395,16 @@ h2 {
   cursor: pointer;
   transform: translateY(-4px);
 }
+
+.wall-list, .group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 8px 0;
+}
+
+.wall-item, .group-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}


### PR DESCRIPTION
## Summary
- allow surfaces to be toggled via checkbox and group them with a color
- clear hover timer when leaving the canvas
- keep track of painted surfaces and groups
- add simple styles for wall/group lists

## Testing
- `npm run build`
- `npx tsc -p tsconfig.json`
- `npm run lint`
