### PR TITLE
Optimize group color editing

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react';
 interface ColorPickerProps {
   value: string;
   onChange: (color: string) => void;
+  onChangeComplete?: (color: string) => void;
 }
 
 interface HSV {
@@ -101,13 +102,22 @@ const rgbToHex = ({ r, g, b }: RGB): string => {
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 };
 
-export default function ColorPicker({ value, onChange }: ColorPickerProps) {
+export default function ColorPicker({ value, onChange, onChangeComplete }: ColorPickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [hsv, setHSV] = useState<HSV>(hexToHSV(value));
   const [hexInput, setHexInput] = useState(value.toUpperCase());
   const [rgb, setRgb] = useState<RGB>(hexToRGB(value));
   const [supportsEyeDropper, setSupportsEyeDropper] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
+  const wasOpen = useRef(false);
+
+  // Notify parent when the user closes the picker
+  useEffect(() => {
+    if (wasOpen.current && !isOpen) {
+      onChangeComplete?.(HSVToHex(hsv));
+    }
+    wasOpen.current = isOpen;
+  }, [isOpen, hsv, onChangeComplete]);
 
   useEffect(() => {
     const newHSV = hexToHSV(value);

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -593,7 +593,11 @@ export default function ImageCanvas({ imageUrl, selectedColor }: ImageCanvasProp
     saveToHistory();
   };
 
-  const updateGroupColor = (groupId: string, color: string) => {
+  const previewGroupColor = (groupId: string, color: string) => {
+    setGroups(groups.map(g => g.id === groupId ? { ...g, color } : g));
+  };
+
+  const commitGroupColor = (groupId: string, color: string) => {
     setGroups(groups.map(g => g.id === groupId ? { ...g, color } : g));
     const updated = walls.map(w =>
       w.groupId === groupId ? { ...w, color } : w
@@ -649,7 +653,11 @@ export default function ImageCanvas({ imageUrl, selectedColor }: ImageCanvasProp
         {groups.map(g => (
           <div key={g.id} className="group-item">
             <span>{g.name}</span>
-            <ColorPicker value={g.color} onChange={c => updateGroupColor(g.id, c)} />
+            <ColorPicker
+              value={g.color}
+              onChange={c => previewGroupColor(g.id, c)}
+              onChangeComplete={c => commitGroupColor(g.id, c)}
+            />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- allow `ColorPicker` to report when it closes via `onChangeComplete`
- use preview/commit flow for updating group colors

## Testing
- `npm run lint`