### PR TITLE
Fix night lighting preset

### DIFF
--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -25,7 +25,8 @@ const LIGHTING_SETTINGS: Record<string, LightingPreset> = {
   morning: { r: 1.1, g: 1.05, b: 0.95, brightness: 1.1 },
   afternoon: { r: 1.05, g: 1.05, b: 1.1, brightness: 1 },
   evening: { r: 1.1, g: 0.9, b: 0.8, brightness: 1 },
-  night: { r: 1.15, g: 1, b: 0.85, brightness: 0.7 },
+  // Night mode simulates indoor LED lighting rather than moonlight
+  night: { r: 0.9, g: 0.95, b: 1.1, brightness: 0.8 },
   cloudy: { r: 0.95, g: 1, b: 1.1, brightness: 0.95 }
 };
 

--- a/src/components/LightingSelector.tsx
+++ b/src/components/LightingSelector.tsx
@@ -9,7 +9,7 @@ export const LIGHTING_PRESETS = {
   morning: 'Morning Sun',
   afternoon: 'Afternoon Sun',
   evening: 'Evening',
-  night: 'Night Lights',
+  night: 'Night Lights (LED)',
   cloudy: 'Cloudy Day'
 };
 


### PR DESCRIPTION
## Summary
- adjust `night` preset in `ImageCanvas` to use indoor LED lighting
- rename lighting option label

## Testing
- `npm run lint`
