### PR TITLE
UI layout fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,7 +19,7 @@ h1 {
 
 .main-content {
   display: grid;
-  grid-template-columns: 320px 1fr 320px;
+  grid-template-columns: 320px 1fr;
   gap: var(--spacing-lg);
   min-height: 600px;
   align-items: flex-start;
@@ -34,23 +34,17 @@ h1 {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 
-.upload-section,
-.color-picker-section {
+
+.panel-section {
   margin-bottom: 2rem;
 }
 
-.white-balance-section {
-  margin-bottom: 2rem;
-}
 
-.lighting-selector {
-  margin-bottom: 2rem;
-}
-
-.lighting-selector label {
-  display: block;
-  margin-bottom: 0.5rem;
+.lighting-selector h2 {
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
   color: #444;
+  font-family: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
 .lighting-selector select {
@@ -64,6 +58,7 @@ h2 {
   font-size: 1.2rem;
   margin-bottom: 1rem;
   color: #444;
+  font-family: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
 .file-input {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,7 +56,7 @@ function App() {
       <h1>Interior Design Color Visualizer</h1>
       <div className="main-content">
         <div className="controls-panel">
-          <div className="upload-section">
+          <div className="upload-section panel-section">
             <h2>Upload Image</h2>
             <input
               type="file"
@@ -65,7 +65,7 @@ function App() {
               className="file-input"
             />
           </div>
-          <div className="color-picker-section">
+          <div className="color-picker-section panel-section">
             <h2>Select Wall Color</h2>
             <ColorPicker
               value={selectedColor}
@@ -75,7 +75,7 @@ function App() {
               Click and drag on the walls to apply the selected color
             </p>
           </div>
-          <div className="white-balance-section">
+          <div className="white-balance-section panel-section">
             <h2>White Balance</h2>
             <WhiteBalanceControls
               value={whiteBalance}
@@ -83,7 +83,7 @@ function App() {
               onAuto={() => selectedImage && computeAutoWhiteBalance(selectedImage).then(setWhiteBalance)}
             />
           </div>
-          <LightingSelector value={lighting} onChange={setLighting} />
+          <LightingSelector value={lighting} onChange={setLighting} className="panel-section" />
         </div>
         <div className="canvas-container">
           {selectedImage ? (

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -134,7 +134,9 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
         console.error('Failed to initialize SAM2:', error);
         setStatus('Failed to initialize SAM2');
       } finally {
-        setIsProcessing(false);
+        // Wait a bit to allow the WASM runtime to finish any remaining work
+        // before removing the processing overlay so the UI remains responsive.
+        setTimeout(() => setIsProcessing(false), 500);
       }
     }
 
@@ -237,7 +239,7 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
       console.error('Failed to process image:', error);
       setStatus('Failed to process image');
     } finally {
-      setIsProcessing(false);
+      setTimeout(() => setIsProcessing(false), 100);
     }
   }
   process();
@@ -379,7 +381,7 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
       console.error('Failed to generate/apply mask:', error);
       setStatus('Failed to generate mask');
     } finally {
-      setIsProcessing(false);
+      setTimeout(() => setIsProcessing(false), 100);
     }
   };
 

--- a/src/components/LightingSelector.tsx
+++ b/src/components/LightingSelector.tsx
@@ -2,6 +2,7 @@
 interface LightingSelectorProps {
   value: string;
   onChange: (mode: string) => void;
+  className?: string;
 }
 
 export const LIGHTING_PRESETS = {
@@ -13,10 +14,10 @@ export const LIGHTING_PRESETS = {
   cloudy: 'Cloudy Day'
 };
 
-export default function LightingSelector({ value, onChange }: LightingSelectorProps) {
+export default function LightingSelector({ value, onChange, className }: LightingSelectorProps) {
   return (
-    <div className="lighting-selector">
-      <label>Lighting</label>
+    <div className={`lighting-selector ${className ?? ''}`.trim()}>
+      <h2>Lighting</h2>
       <select value={value} onChange={(e) => onChange(e.target.value)}>
         {Object.entries(LIGHTING_PRESETS).map(([key, label]) => (
           <option key={key} value={key}>{label}</option>


### PR DESCRIPTION
## Summary
- standardize panel styling with `.panel-section`
- streamline headings using Poppins font
- collapse main layout to two columns so sidebar fits
- allow LightingSelector to accept extra classes
- keep SAM overlay slightly longer for smoother load

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683b4b5c42948333a86d8b0e9ce7337c