### PR TITLE
Fix groups layout pane

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,7 +19,7 @@ h1 {
 
 .main-content {
   display: grid;
-  grid-template-columns: 320px 1fr;
+  grid-template-columns: 320px 1fr 320px;
   gap: var(--spacing-lg);
   min-height: 600px;
   align-items: flex-start;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import './App.css'
 import ImageCanvas from './components/ImageCanvas'
 import ColorPicker from './components/ColorPicker'
@@ -10,6 +10,7 @@ function App() {
   const [selectedColor, setSelectedColor] = useState<string>('#ffffff')
   const [whiteBalance, setWhiteBalance] = useState<WhiteBalance>({ r: 1, g: 1, b: 1 })
   const [lighting, setLighting] = useState('normal')
+  const sidebarRef = useRef<HTMLDivElement>(null)
 
   const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
@@ -92,6 +93,7 @@ function App() {
               selectedColor={selectedColor}
               whiteBalance={whiteBalance}
               lighting={lighting}
+              sidebarContainer={sidebarRef.current}
             />
           ) : (
             <div className="upload-placeholder">
@@ -99,6 +101,7 @@ function App() {
             </div>
           )}
         </div>
+        <div ref={sidebarRef} className="sidebar" />
       </div>
     </div>
   )

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import ColorPicker from './ColorPicker';
 import { SAM2 } from '../lib/sam';
 import { AVAILABLE_MODELS, getModelFiles } from '../lib/sam/model-loader';
@@ -60,6 +61,7 @@ interface ImageCanvasProps {
   selectedColor: string;
   whiteBalance: WhiteBalance;
   lighting: string;
+  sidebarContainer?: HTMLElement | null;
 }
 
 interface HistoryState {
@@ -83,7 +85,7 @@ interface WallGroup {
 }
 
 
-export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lighting }: ImageCanvasProps) {
+export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lighting, sidebarContainer }: ImageCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [rawImageData, setRawImageData] = useState<ImageData | null>(null);
   const [originalImageData, setOriginalImageData] = useState<ImageData | null>(null);
@@ -661,6 +663,56 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
     applyLighting(ctx, canvas.width, canvas.height, lighting);
   }, [lighting, baseImageData]);
 
+  const groupsSidebar = (
+    <>
+      <button className="add-group" onClick={addGroup}>Add Group</button>
+      {groups.map(g => (
+        <div key={g.id} className="group-section">
+          <div className="group-header">
+            <span>{g.name}</span>
+            <ColorPicker
+              value={g.color}
+              onChange={c => previewGroupColor(g.id, c)}
+              onChangeComplete={c => commitGroupColor(g.id, c)}
+            />
+          </div>
+          <ul className="group-surfaces">
+            {walls.filter(w => w.groupId === g.id).map(w => (
+              <li key={w.id}>
+                <label>
+                  <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
+                </label>
+                <button onClick={() => assignWallToGroup(w.id, null)}>Remove</button>
+              </li>
+            ))}
+            <li>
+              <select onChange={e => { const wid = e.target.value; if (wid) { assignWallToGroup(wid, g.id); e.target.value=''; } }}>
+                <option value="">Add surface...</option>
+                {walls.filter(w => w.groupId !== g.id).map(w => (
+                  <option key={w.id} value={w.id}>{w.id}</option>
+                ))}
+              </select>
+            </li>
+          </ul>
+        </div>
+      ))}
+      {walls.filter(w => !w.groupId).length > 0 && (
+        <div className="group-section">
+          <div className="group-header"><span>Other</span></div>
+          <ul className="group-surfaces">
+            {walls.filter(w => !w.groupId).map(w => (
+              <li key={w.id}>
+                <label>
+                  <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
+                </label>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+
   return (
     <div className="canvas-wrapper">
       <div className="canvas-controls">
@@ -689,54 +741,8 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
             </div>
           )}
         </div>
-        <div className="sidebar">
-          <button className="add-group" onClick={addGroup}>Add Group</button>
-          {groups.map(g => (
-            <div key={g.id} className="group-section">
-              <div className="group-header">
-                <span>{g.name}</span>
-                <ColorPicker
-                  value={g.color}
-                  onChange={c => previewGroupColor(g.id, c)}
-                  onChangeComplete={c => commitGroupColor(g.id, c)}
-                />
-              </div>
-              <ul className="group-surfaces">
-                {walls.filter(w => w.groupId === g.id).map(w => (
-                  <li key={w.id}>
-                    <label>
-                      <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
-                    </label>
-                    <button onClick={() => assignWallToGroup(w.id, null)}>Remove</button>
-                  </li>
-                ))}
-                <li>
-                  <select onChange={e => { const wid = e.target.value; if (wid) { assignWallToGroup(wid, g.id); e.target.value=''; } }}>
-                    <option value="">Add surface...</option>
-                    {walls.filter(w => w.groupId !== g.id).map(w => (
-                      <option key={w.id} value={w.id}>{w.id}</option>
-                    ))}
-                  </select>
-                </li>
-              </ul>
-            </div>
-          ))}
-          {walls.filter(w => !w.groupId).length > 0 && (
-            <div className="group-section">
-              <div className="group-header"><span>Other</span></div>
-              <ul className="group-surfaces">
-                {walls.filter(w => !w.groupId).map(w => (
-                  <li key={w.id}>
-                    <label>
-                      <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
-                    </label>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
       </div>
+      {sidebarContainer && createPortal(groupsSidebar, sidebarContainer)}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- split out groups sidebar into its own pane using React portals
- update App layout to include third pane
- adjust CSS grid for three-pane layout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683b4dfb84cc8333a6138342f773f968