### PR TITLE
Add icon-based controls and new color scheme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -254,7 +254,7 @@ h2 {
 }
 
 .hsv-slider input[type="range"]::-webkit-slider-thumb:hover {
-  background: #006be6;
+  background: var(--accent-hover);
 }
 
 .hsv-slider:nth-child(1) input[type="range"] {
@@ -299,24 +299,35 @@ h2 {
 }
 
 .canvas-controls {
+  position: absolute;
+  top: 8px;
+  left: 8px;
   display: flex;
-  gap: 0.5rem;
-  justify-content: center;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 4px;
+  border-radius: 6px;
+  z-index: 10;
 }
 
 .canvas-controls button {
-  padding: 0.5rem 1rem;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   border: none;
-  border-radius: 6px;
+  border-radius: 4px;
   background-color: var(--accent-color);
   color: white;
   cursor: pointer;
   font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: background-color 0.2s;
 }
 
 .canvas-controls button:hover {
-  background-color: #006be6;
+  background-color: var(--accent-hover);
 }
 
 .canvas-controls button:disabled {
@@ -473,6 +484,14 @@ h2 {
   border: none;
   border-radius: 6px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.add-group svg {
+  width: 16px;
+  height: 16px;
 }
 
 .group-section {
@@ -500,6 +519,20 @@ h2 {
   align-items: center;
   gap: 6px;
   margin-bottom: 4px;
+}
+
+.remove-btn {
+  background: none;
+  border: none;
+  color: var(--accent-color);
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+}
+
+.remove-btn:hover {
+  color: var(--accent-hover);
 }
 
 .canvas-area {

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,0 +1,41 @@
+import type { SVGProps } from 'react';
+
+export function UndoIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20" {...props}>
+      <path d="M12 5V2L7 7l5 5V9c3.9 0 7 3.1 7 7s-3.1 7-7 7-7-3.1-7-7h2c0 2.8 2.2 5 5 5s5-2.2 5-5-2.2-5-5-5z" />
+    </svg>
+  );
+}
+
+export function RedoIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20" {...props}>
+      <path d="M12 5V2l5 5-5 5V9c-3.9 0-7 3.1-7 7s3.1 7 7 7 7-3.1 7-7h-2c0 2.8-2.2 5-5 5s-5-2.2-5-5 2.2-5 5-5z" />
+    </svg>
+  );
+}
+
+export function ResetIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20" {...props}>
+      <path d="M12 4V1L8 5l4 4V6a6 6 0 110 12 6 6 0 01-6-6H4a8 8 0 108-8z" />
+    </svg>
+  );
+}
+
+export function TrashIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20" {...props}>
+      <path d="M3 6h18v2H3V6zm2 3h14l-1 11a2 2 0 01-2 2H6a2 2 0 01-2-2L3 9h2zm5 2v7h2v-7H10zm4 0v7h2v-7h-2zM9 4h6l1 1h4v2H4V5h4l1-1z" />
+    </svg>
+  );
+}
+
+export function PlusIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20" {...props}>
+      <path d="M11 5v6H5v2h6v6h2v-6h6v-2h-6V5h-2z" />
+    </svg>
+  );
+}

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import ColorPicker from './ColorPicker';
+import { UndoIcon, RedoIcon, ResetIcon, TrashIcon, PlusIcon } from './Icons';
 import { SAM2 } from '../lib/sam';
 import { AVAILABLE_MODELS, getModelFiles } from '../lib/sam/model-loader';
 import {
@@ -663,13 +664,27 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
 
   return (
     <div className="canvas-wrapper">
-      <div className="canvas-controls">
-        <button onClick={undo} disabled={currentHistoryIndex <= 0 || isProcessing}>Undo</button>
-        <button onClick={redo} disabled={currentHistoryIndex >= history.length - 1 || isProcessing}>Redo</button>
-        <button onClick={reset} disabled={isProcessing}>Reset</button>
-      </div>
       <div className="canvas-content">
         <div className="canvas-area">
+          <div className="canvas-controls">
+            <button
+              title="Undo"
+              onClick={undo}
+              disabled={currentHistoryIndex <= 0 || isProcessing}
+            >
+              <UndoIcon />
+            </button>
+            <button
+              title="Redo"
+              onClick={redo}
+              disabled={currentHistoryIndex >= history.length - 1 || isProcessing}
+            >
+              <RedoIcon />
+            </button>
+            <button title="Reset" onClick={reset} disabled={isProcessing}>
+              <ResetIcon />
+            </button>
+          </div>
           <canvas
             ref={canvasRef}
             onMouseDown={handleMouseDown}
@@ -690,7 +705,10 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
           )}
         </div>
         <div className="sidebar">
-          <button className="add-group" onClick={addGroup}>Add Group</button>
+          <button className="add-group" onClick={addGroup}>
+            <PlusIcon />
+            <span>Add Group</span>
+          </button>
           {groups.map(g => (
             <div key={g.id} className="group-section">
               <div className="group-header">
@@ -707,7 +725,13 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
                     <label>
                       <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
                     </label>
-                    <button onClick={() => assignWallToGroup(w.id, null)}>Remove</button>
+                    <button
+                      className="remove-btn"
+                      title="Remove surface from group"
+                      onClick={() => assignWallToGroup(w.id, null)}
+                    >
+                      <TrashIcon />
+                    </button>
                   </li>
                 ))}
                 <li>

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,8 @@
   font-weight: 400;
 
   /* Light mode as the default look */
-  --accent-color: #0a84ff;
+  --accent-color: #9d7cd8;
+  --accent-hover: #875dc4;
   /* Spacing scale */
   --spacing-xs: 4px;
   --spacing-sm: 8px;
@@ -15,7 +16,7 @@
   --spacing-xl: 32px;
   color-scheme: light;
   color: #1c1c1e;
-  background-color: #f5f5f7;
+  background-color: #f6f1fb;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -29,7 +30,7 @@ a {
   text-decoration: inherit;
 }
 a:hover {
-  color: #006be6;
+  color: var(--accent-hover);
 }
 
 body {
@@ -59,7 +60,7 @@ button {
   transition: background-color 0.25s;
 }
 button:hover {
-  background-color: #006be6;
+  background-color: var(--accent-hover);
 }
 button:focus,
 button:focus-visible {


### PR DESCRIPTION
## Summary
- add shared icon components
- switch undo/redo/reset to use icons
- swap Remove button for trash icon
- add icon to "Add Group" button
- overlay action bar on canvas and tweak styles
- use pastel purple accent color with complementary background

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683b4ef16b90833392f9aa9912a0f8da