### PR TITLE
Fix trash icon hover, add tooltips, pad sidebar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -471,9 +471,10 @@ h2 {
   gap: var(--spacing-md);
   background: #fafafa;
   border-left: 1px solid #e0e0e0;
-  padding-left: var(--spacing-md);
+  padding: var(--spacing-lg) var(--spacing-md);
   /* Allow popups like the color picker to extend outside */
   overflow: visible;
+  min-height: 400px;
 }
 
 .add-group {
@@ -529,9 +530,11 @@ h2 {
   padding: 2px;
   display: flex;
   align-items: center;
+  background-color: transparent;
 }
 
 .remove-btn:hover {
+  background-color: transparent;
   color: var(--accent-hover);
 }
 
@@ -579,7 +582,7 @@ h2 {
     width: 100%;
     max-width: none;
     border-left: none;
-    padding-left: 0;
+    padding: var(--spacing-lg) var(--spacing-md);
   }
   .canvas-content {
     flex-direction: column;

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -670,7 +670,7 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
 
   const groupsSidebar = (
     <>
-      <button className="add-group" onClick={addGroup}>
+      <button className="add-group" onClick={addGroup} title="Add group">
         <PlusIcon />
         <span>Add Group</span>
       </button>


### PR DESCRIPTION
## Summary
- ensure sidebar has padding and min-height
- add tooltip to "Add Group" button
- prevent purple hover background on trash icon button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683b53a0a7548333a3c30dfa21a8283f