### PR TITLE
Add simple navigation and Why page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,7 +14,70 @@
 h1 {
   text-align: center;
   color: #1c1c1e;
-  margin-bottom: 2rem;
+  margin: 0;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.nav-menu {
+  position: relative;
+}
+
+.hamburger {
+  background: none;
+  border: none;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  cursor: pointer;
+}
+
+.hamburger span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: #1c1c1e;
+}
+
+.menu-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  border-radius: 6px;
+  padding: 0.5rem 0;
+  z-index: 1000;
+}
+
+.menu-dropdown a {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: #1c1c1e;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.menu-dropdown a:hover {
+  background: #f0f0f0;
+}
+
+.why-page {
+  max-width: 800px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.why-page h2 {
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 1rem;
 }
 
 .main-content {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,110 +1,19 @@
-import { useState, useRef } from 'react'
+import { useState } from 'react'
 import './App.css'
-import ImageCanvas from './components/ImageCanvas'
-import ColorPicker from './components/ColorPicker'
-import WhiteBalanceControls, { type WhiteBalance } from './components/WhiteBalanceControls'
-import LightingSelector from './components/LightingSelector'
+import DesignPage from './pages/DesignPage'
+import WhyPage from './pages/WhyPage'
+import NavigationMenu from './components/NavigationMenu'
 
-function App() {
-  const [selectedImage, setSelectedImage] = useState<string | null>(null)
-  const [selectedColor, setSelectedColor] = useState<string>('#ffffff')
-  const [whiteBalance, setWhiteBalance] = useState<WhiteBalance>({ r: 1, g: 1, b: 1 })
-  const [lighting, setLighting] = useState('normal')
-  const sidebarRef = useRef<HTMLDivElement>(null)
-
-  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (file) {
-      const reader = new FileReader()
-      reader.onloadend = () => {
-        const url = reader.result as string
-        setSelectedImage(url)
-        computeAutoWhiteBalance(url).then(setWhiteBalance)
-      }
-      reader.readAsDataURL(file)
-    }
-  }
-
-  const computeAutoWhiteBalance = (url: string): Promise<WhiteBalance> => {
-    return new Promise((resolve) => {
-      const img = new Image()
-      img.src = url
-      img.onload = () => {
-        const canvas = document.createElement('canvas')
-        canvas.width = img.width
-        canvas.height = img.height
-        const ctx = canvas.getContext('2d')!
-        ctx.drawImage(img, 0, 0)
-        const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data
-        let r = 0, g = 0, b = 0
-        const count = canvas.width * canvas.height
-        for (let i = 0; i < data.length; i += 4) {
-          r += data[i]
-          g += data[i + 1]
-          b += data[i + 2]
-        }
-        r /= count
-        g /= count
-        b /= count
-        const gray = (r + g + b) / 3
-        resolve({ r: gray / r, g: gray / g, b: gray / b })
-      }
-    })
-  }
+export default function App() {
+  const [page, setPage] = useState<'home' | 'why'>('home')
 
   return (
     <div className="app-container">
-      <h1>Interior Design Color Visualizer</h1>
-      <div className="main-content">
-        <div className="controls-panel">
-          <div className="upload-section panel-section">
-            <h2>Upload Image</h2>
-            <input
-              type="file"
-              accept="image/*"
-              onChange={handleImageUpload}
-              className="file-input"
-            />
-          </div>
-          <div className="color-picker-section panel-section">
-            <h2>Select Wall Color</h2>
-            <ColorPicker
-              value={selectedColor}
-              onChange={setSelectedColor}
-            />
-            <p className="instructions">
-              Click and drag on the walls to apply the selected color
-            </p>
-          </div>
-          <div className="white-balance-section panel-section">
-            <h2>White Balance</h2>
-            <WhiteBalanceControls
-              value={whiteBalance}
-              onChange={setWhiteBalance}
-              onAuto={() => selectedImage && computeAutoWhiteBalance(selectedImage).then(setWhiteBalance)}
-            />
-          </div>
-          <LightingSelector value={lighting} onChange={setLighting} className="panel-section" />
-        </div>
-        <div className="canvas-container">
-          {selectedImage ? (
-            <ImageCanvas
-              imageUrl={selectedImage}
-              selectedColor={selectedColor}
-              whiteBalance={whiteBalance}
-              lighting={lighting}
-              sidebarContainer={sidebarRef.current}
-            />
-          ) : (
-            <div className="upload-placeholder">
-              <p>Upload an image to begin</p>
-            </div>
-          )}
-        </div>
-        <div ref={sidebarRef} className="sidebar" />
-      </div>
+      <header className="app-header">
+        <NavigationMenu onNavigate={setPage} />
+        <h1>Interior Design Color Visualizer</h1>
+      </header>
+      {page === 'home' ? <DesignPage /> : <WhyPage />}
     </div>
   )
 }
-
-export default App

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+
+interface NavigationMenuProps {
+  onNavigate: (page: 'home' | 'why') => void
+}
+
+export default function NavigationMenu({ onNavigate }: NavigationMenuProps) {
+  const [open, setOpen] = useState(false)
+
+  const handleNav = (page: 'home' | 'why') => {
+    onNavigate(page)
+    setOpen(false)
+  }
+
+  return (
+    <nav className="nav-menu">
+      <button className="hamburger" aria-label="Menu" onClick={() => setOpen(!open)}>
+        <span />
+        <span />
+        <span />
+      </button>
+      {open && (
+        <div className="menu-dropdown">
+          <a onClick={() => handleNav('home')}>Home</a>
+          <a onClick={() => handleNav('why')}>Why</a>
+        </div>
+      )}
+    </nav>
+  )
+}

--- a/src/pages/DesignPage.tsx
+++ b/src/pages/DesignPage.tsx
@@ -1,0 +1,104 @@
+import { useState, useRef } from 'react'
+import ImageCanvas from '../components/ImageCanvas'
+import ColorPicker from '../components/ColorPicker'
+import WhiteBalanceControls, { type WhiteBalance } from '../components/WhiteBalanceControls'
+import LightingSelector from '../components/LightingSelector'
+
+export default function DesignPage() {
+  const [selectedImage, setSelectedImage] = useState<string | null>(null)
+  const [selectedColor, setSelectedColor] = useState<string>('#ffffff')
+  const [whiteBalance, setWhiteBalance] = useState<WhiteBalance>({ r: 1, g: 1, b: 1 })
+  const [lighting, setLighting] = useState('normal')
+  const sidebarRef = useRef<HTMLDivElement>(null)
+
+  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (file) {
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        const url = reader.result as string
+        setSelectedImage(url)
+        computeAutoWhiteBalance(url).then(setWhiteBalance)
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  const computeAutoWhiteBalance = (url: string): Promise<WhiteBalance> => {
+    return new Promise((resolve) => {
+      const img = new Image()
+      img.src = url
+      img.onload = () => {
+        const canvas = document.createElement('canvas')
+        canvas.width = img.width
+        canvas.height = img.height
+        const ctx = canvas.getContext('2d')!
+        ctx.drawImage(img, 0, 0)
+        const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data
+        let r = 0, g = 0, b = 0
+        const count = canvas.width * canvas.height
+        for (let i = 0; i < data.length; i += 4) {
+          r += data[i]
+          g += data[i + 1]
+          b += data[i + 2]
+        }
+        r /= count
+        g /= count
+        b /= count
+        const gray = (r + g + b) / 3
+        resolve({ r: gray / r, g: gray / g, b: gray / b })
+      }
+    })
+  }
+
+  return (
+    <div className="main-content">
+      <div className="controls-panel">
+        <div className="upload-section panel-section">
+          <h2>Upload Image</h2>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleImageUpload}
+            className="file-input"
+          />
+        </div>
+        <div className="color-picker-section panel-section">
+          <h2>Select Wall Color</h2>
+          <ColorPicker
+            value={selectedColor}
+            onChange={setSelectedColor}
+          />
+          <p className="instructions">
+            Click and drag on the walls to apply the selected color
+          </p>
+        </div>
+        <div className="white-balance-section panel-section">
+          <h2>White Balance</h2>
+          <WhiteBalanceControls
+            value={whiteBalance}
+            onChange={setWhiteBalance}
+            onAuto={() => selectedImage && computeAutoWhiteBalance(selectedImage).then(setWhiteBalance)}
+          />
+        </div>
+        <LightingSelector value={lighting} onChange={setLighting} className="panel-section" />
+      </div>
+      <div className="canvas-container">
+        {selectedImage ? (
+          <ImageCanvas
+            imageUrl={selectedImage}
+            selectedColor={selectedColor}
+            whiteBalance={whiteBalance}
+            lighting={lighting}
+            sidebarContainer={sidebarRef.current}
+          />
+        ) : (
+          <div className="upload-placeholder">
+            <p>Upload an image to begin</p>
+          </div>
+        )}
+      </div>
+      <div ref={sidebarRef} className="sidebar" />
+    </div>
+  )
+}

--- a/src/pages/WhyPage.tsx
+++ b/src/pages/WhyPage.tsx
@@ -1,0 +1,24 @@
+export default function WhyPage() {
+  return (
+    <div className="why-page">
+      <h2>Why We Built This App</h2>
+      <p>
+        Many online paint visualizers simply overlay a flat color onto your
+        photo. Sites from brands like Benjamin Moore and Dunn-Edwards provide a
+        quick preview, but the results often look unnatural and ignore the way
+        light interacts with real walls.
+      </p>
+      <p>
+        We wanted a more accurate approach to help homeowners truly understand
+        how a color will appear in their own space. By leveraging Meta's Segment
+        Anything Model we can isolate walls with much greater precision and
+        preserve the original lighting and shadows of the room.
+      </p>
+      <p>
+        Our goal is to experiment with modern segmentation techniques and offer
+        a smoother workflow for exploring paint options. We hope this project
+        sparks new ideas for improving the design tools available to everyone.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a navigation hamburger menu
- add dedicated `Why` page describing goals and critiques of existing paint apps
- restructure `App` to switch between Home and Why pages
- reduce title spacing and add header styling

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683b54d6b5c483338bcd01dee4cc79bc