### PR TITLE
Fix header layout and hamburger menu

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,13 +1,13 @@
 #root {
   width: 100%;
-  padding: var(--spacing-lg);
+  padding: 0 var(--spacing-lg) var(--spacing-lg);
   box-sizing: border-box;
 }
 
 .app-container {
   width: 100%;
   margin: 0;
-  padding: var(--spacing-lg);
+  padding: 0 var(--spacing-lg) var(--spacing-lg);
   box-sizing: border-box;
 }
 
@@ -18,14 +18,16 @@ h1 {
 }
 
 .app-header {
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: 1rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
 }
 
 .nav-menu {
-  position: relative;
+  position: absolute;
+  left: 0;
 }
 
 .hamburger {
@@ -48,7 +50,7 @@ h1 {
 .menu-dropdown {
   position: absolute;
   top: 100%;
-  right: 0;
+  left: 0;
   background: #fff;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   border-radius: 6px;

--- a/src/index.css
+++ b/src/index.css
@@ -35,8 +35,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- center header title and pin hamburger to the left
- left-align dropdown menu
- remove top padding and extra body styling so header sits at the top

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683b577fdec48333b009b851402055f4