### PR TITLE
Fix drag and drop of walls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -587,6 +587,13 @@ h2 {
   align-items: center;
   gap: 6px;
   margin-bottom: 4px;
+  border-left: 4px solid var(--accent-color);
+  padding-left: 6px;
+  cursor: grab;
+}
+
+.group-surfaces li:active {
+  cursor: grabbing;
 }
 
 .remove-btn {

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -721,7 +721,14 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
             onDrop={e => handleDrop(e, g.id)}
           >
             {walls.filter(w => w.groupId === g.id).map(w => (
-              <li key={w.id} draggable onDragStart={e => handleDragStart(e, w.id)}>
+              <li
+                key={w.id}
+                className="draggable"
+                draggable
+                onDragStart={e => handleDragStart(e, w.id)}
+                onDragOver={allowDrop}
+                onDrop={e => handleDrop(e, g.id)}
+              >
                 <label>
                   <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
                 </label>
@@ -746,7 +753,14 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
             onDrop={e => handleDrop(e, null)}
           >
             {walls.filter(w => !w.groupId).map(w => (
-              <li key={w.id} draggable onDragStart={e => handleDragStart(e, w.id)}>
+              <li
+                key={w.id}
+                className="draggable"
+                draggable
+                onDragStart={e => handleDragStart(e, w.id)}
+                onDragOver={allowDrop}
+                onDrop={e => handleDrop(e, null)}
+              >
                 <label>
                   <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
                 </label>


### PR DESCRIPTION
## Summary
- fix drop handler on group surface list items
- mark draggable surfaces with a left border and grab cursor

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683b5b3c84308333908a90e435eaeeb8