### PR TITLE
Fix UI text for surface coloring

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -7,7 +7,7 @@ This document captures the visual design guidelines used across the application.
 - The application uses a **three‑pane layout** when there is enough horizontal space.
   - **Left panel** – upload and basic color controls.
   - **Center panel** – main canvas area that remains fixed.
-  - **Right panel** – dynamic widgets such as wall groups.
+  - **Right panel** – dynamic widgets such as surface groups.
 - The layout uses CSS Grid with `grid-template-columns: 320px 1fr 320px` and collapses to a single column on small screens.
 - Containers stretch to the full width of the viewport to support edge‑to‑edge designs.
 

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -98,6 +98,7 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
   const [status, setStatus] = useState<string>('');
   const [walls, setWalls] = useState<WallSurface[]>([]);
   const [groups, setGroups] = useState<WallGroup[]>([]);
+  const surfaceCounter = useRef(1);
 
   const retinexRef = useRef<{
     L: Float32Array;
@@ -374,13 +375,13 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
         historyImage = updated;
       }
 
-      const newWall: WallSurface = {
-        id: `wall-${Date.now()}`,
-        pixels: indices,
-        color: selectedColor,
-        enabled: true,
-        groupId: null
-      };
+        const newWall: WallSurface = {
+          id: `Surface ${surfaceCounter.current++}`,
+          pixels: indices,
+          color: selectedColor,
+          enabled: true,
+          groupId: null
+        };
       setWalls([...walls, newWall]);
 
       // Save to history

--- a/src/pages/DesignPage.tsx
+++ b/src/pages/DesignPage.tsx
@@ -64,13 +64,13 @@ export default function DesignPage() {
           />
         </div>
         <div className="color-picker-section panel-section">
-          <h2>Select Wall Color</h2>
+          <h2>Select Surface Color</h2>
           <ColorPicker
             value={selectedColor}
             onChange={setSelectedColor}
           />
           <p className="instructions">
-            Click and drag on the walls to apply the selected color
+            Hover over the image to highlight surfaces. Click to apply the color.
           </p>
         </div>
         <div className="white-balance-section panel-section">

--- a/src/pages/WhyPage.tsx
+++ b/src/pages/WhyPage.tsx
@@ -6,12 +6,12 @@ export default function WhyPage() {
         Many online paint visualizers simply overlay a flat color onto your
         photo. Sites from brands like Benjamin Moore and Dunn-Edwards provide a
         quick preview, but the results often look unnatural and ignore the way
-        light interacts with real walls.
+        light interacts with real surfaces.
       </p>
       <p>
         We wanted a more accurate approach to help homeowners truly understand
         how a color will appear in their own space. By leveraging Meta's Segment
-        Anything Model we can isolate walls with much greater precision and
+        Anything Model we can isolate surfaces with much greater precision and
         preserve the original lighting and shadows of the room.
       </p>
       <p>


### PR DESCRIPTION
## Summary
- avoid using the word "wall" in user-facing text
- update instructions for applying color
- match design docs to new terminology
- generate friendly names like "Surface 1" for new surfaces

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683e4e5f58408333a13e89b1495da861