### PR TITLE
Fix empty group drag drop

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -569,11 +569,24 @@ h2 {
 }
 
 .group-name-input {
-  flex: 1;
+  width: 100%;
   padding: 4px 6px;
   border: 1px solid #ddd;
   border-radius: 6px;
   font-weight: 600;
+}
+
+.group-name-display {
+  font-weight: 600;
+  padding: 4px 6px;
+  cursor: text;
+}
+
+.color-picker-label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.8rem;
+  gap: 4px;
 }
 
 .group-section {
@@ -585,15 +598,18 @@ h2 {
 
 .group-header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  gap: 4px;
   margin-bottom: 0.25rem;
 }
 
 .group-surfaces {
   list-style: none;
-  padding: 0;
+  padding: 4px;
   margin: 0;
+  min-height: 2rem;
+  border: 1px dashed var(--accent-color);
+  border-radius: 4px;
 }
 
 .group-surfaces li {
@@ -608,6 +624,12 @@ h2 {
 
 .group-surfaces li:active {
   cursor: grabbing;
+}
+
+.group-surfaces .drop-placeholder {
+  color: #666;
+  font-style: italic;
+  padding-left: 6px;
 }
 
 .remove-btn {


### PR DESCRIPTION
## Summary
- allow dropping into empty groups by giving `.group-surfaces` a min height and border
- show a placeholder list item so the drop target exists even with no surfaces
- place group name on its own line and only show input box when editing
- label the color picker and show it below the name

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683e592cbec48333b6fc193f9e773ae5