### PR TITLE
Finalize group UI and drop behavior

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -576,6 +576,10 @@ h2 {
   font-weight: 600;
 }
 
+.group-name-input::placeholder {
+  font-style: italic;
+}
+
 .group-name-display {
   font-weight: 600;
   padding: 4px 6px;

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -645,14 +645,26 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
     const wall = walls.find(w => w.id === wallId);
     if (!wall) return;
 
-    const newColor = groupId ? (groups.find(g => g.id === groupId)?.color || wall.color) : wall.color;
-    const updatedWall = { ...wall, groupId, color: newColor };
+    const newColor = groupId
+      ? groups.find(g => g.id === groupId)?.color || wall.color
+      : wall.color;
+    const updatedWall = { ...wall, groupId, color: newColor, enabled: true };
 
-    if (newColor !== wall.color) {
+    if (wall.enabled && newColor === wall.color) {
+      setWalls(walls.map(w => (w.id === wallId ? updatedWall : w)));
+      saveToHistory();
+      return;
+    }
+
+    if (wall.enabled) {
       recolorWall(updatedWall, newColor);
     } else {
-      setWalls(walls.map(w => w.id === wallId ? updatedWall : w));
-      saveToHistory();
+      const updatedWalls = walls.map(w =>
+        w.id === wallId ? updatedWall : w
+      );
+      setWalls(updatedWalls);
+      const base = reapplyWalls(updatedWalls);
+      saveToHistory(base ?? undefined);
     }
 
   };
@@ -733,17 +745,18 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
         Drag surfaces here to organize them. Edit the names below and use the
         color picker to set a group's color.
       </p>
+      <h3>Add Group</h3>
       <div className="add-group-row">
         <input
           type="text"
           className="group-name-input"
-          placeholder="New group name"
+          placeholder="Enter group name"
           value={newGroupName}
           onChange={e => setNewGroupName(e.target.value)}
         />
         <button className="add-group" onClick={addGroup} title="Add group">
           <PlusIcon />
-          <span>Add Group</span>
+          <span>Add</span>
         </button>
       </div>
       {groups.map(g => (


### PR DESCRIPTION
## Summary
- tweak group creation UI text
- italicize group input placeholder
- when dragging a surface to a group mark it enabled if needed

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683e5e0f86b08333a3a558a50392101c