### PR TITLE
Improve SAM initialization statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ npm run build
 npm run preview  # to preview the build
 ```
 
+## Enabling WebAssembly Multi-Threading
+
+ONNX Runtime can leverage WebAssembly threads for better performance. Browsers
+require the page to be **cross-origin isolated** to enable this feature. When
+deploying to platforms like Vercel, ensure the following headers are served:
+
+```
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+If you cannot configure headers directly, you can register a small service
+worker using [`coi-serviceworker`](https://github.com/gzuidhof/coi-serviceworker)
+before loading the app:
+
+```html
+<script src="https://unpkg.com/coi-serviceworker" defer></script>
+```
+
+Once the page is cross-origin isolated, the app will use four WASM threads as
+configured in `src/lib/sam/index.ts`.
+
 ## License
 
 MIT

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -125,18 +125,17 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
         setStatus('Initializing SAM2...');
         // Start with tiny model for faster loading
         const modelInfo = AVAILABLE_MODELS[0];
-        const { encoderPath, decoderPath } = await getModelFiles(modelInfo);
+        const { encoderPath, decoderPath } = await getModelFiles(modelInfo, setStatus);
 
         const samInstance = new SAM2({
           encoderPath,
           decoderPath,
-          modelSize: modelInfo.size
+          modelSize: modelInfo.size,
+          onStatus: setStatus
         });
 
-        setStatus('Loading SAM2 model...');
         await samInstance.initialize();
         setSam(samInstance);
-        setStatus('SAM2 initialized');
       } catch (error) {
         console.error('Failed to initialize SAM2:', error);
         setStatus('Failed to initialize SAM2');


### PR DESCRIPTION
## Summary
- show status during SAM initialization
- allow model loader to report status updates
- document how to enable WASM multithreading

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683e64d001548333878af9e13a0961e4