### PR TITLE
Add persistent status bar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -674,6 +674,19 @@ h2 {
   color: #333;
 }
 
+.status-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.25rem 0;
+  text-align: center;
+  font-size: 0.9rem;
+  color: #333;
+  background: rgba(255, 255, 255, 0.9);
+  pointer-events: none;
+}
+
 .spinner {
   width: 40px;
   height: 40px;

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -907,6 +907,9 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
               <span>{status}</span>
             </div>
           )}
+          {!isProcessing && status && (
+            <div className="status-bar">{status}</div>
+          )}
         </div>
       </div>
       {sidebarContainer && createPortal(groupsSidebar, sidebarContainer)}


### PR DESCRIPTION
## Summary
- show status text in a new status bar when processing finishes
- style the status bar

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683e74bb6b0083339ac9396ea37dac73