### PR TITLE
Improve loading feedback and reposition status bar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -675,15 +675,13 @@ h2 {
 }
 
 .status-bar {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 0.25rem 0;
+  margin-top: var(--spacing-sm);
   text-align: center;
   font-size: 0.9rem;
   color: #333;
   background: rgba(255, 255, 255, 0.9);
+  padding: 0.25rem 0;
+  border-radius: 6px;
   pointer-events: none;
 }
 
@@ -695,6 +693,13 @@ h2 {
   border-radius: 50%;
   animation: spin 1s linear infinite;
   margin-bottom: 0.5rem;
+}
+
+.spinner-large {
+  width: 80px;
+  height: 80px;
+  border-width: 6px;
+  margin-bottom: 1rem;
 }
 
 @keyframes spin {

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -903,15 +903,15 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
           />
           {isProcessing && (
             <div className="processing-overlay">
-              <div className="spinner" />
+              <div
+                className={`spinner${!sam ? ' spinner-large' : ''}`}
+              />
               <span>{status}</span>
             </div>
           )}
-          {!isProcessing && status && (
-            <div className="status-bar">{status}</div>
-          )}
         </div>
       </div>
+      {!isProcessing && status && <div className="status-bar">{status}</div>}
       {sidebarContainer && createPortal(groupsSidebar, sidebarContainer)}
     </div>
   );


### PR DESCRIPTION
## Summary
- keep status text below the canvas instead of overlapping the image
- show a larger spinner while the SAM model is downloading

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683e76dd0ecc833390cca420eae4cc64