### PR TITLE
Disable modulePreload polyfill

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,5 +13,10 @@ export default defineConfig({
       'Cross-Origin-Opener-Policy': 'same-origin',
       'Cross-Origin-Embedder-Policy': 'require-corp'
     }
+  },
+  build: {
+    modulePreload: {
+      polyfill: false
+    }
   }
 })


### PR DESCRIPTION
## Summary
- disable modulePreload polyfill so workers don't reference `document`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683e81ddde288333857f8dfd9168231b