### PR TITLE
Preserve design page state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,13 @@ export default function App() {
         <NavigationMenu onNavigate={setPage} />
         <h1>Interior Design Color Visualizer</h1>
       </header>
-      {page === 'home' ? <DesignPage /> : <WhyPage />}
+      {/* Render both pages to preserve state when navigating */}
+      <div style={{ display: page === 'home' ? 'block' : 'none' }}>
+        <DesignPage />
+      </div>
+      <div style={{ display: page === 'why' ? 'block' : 'none' }}>
+        <WhyPage />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- mount both pages and hide the inactive one to keep state when toggling navigation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683e81f7a8808333b85fe747ecc44e69