### PR TITLE
Improve spinner display during processing

### DIFF
--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -96,6 +96,8 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
   const [sam, setSam] = useState<SAM2 | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [status, setStatus] = useState<string>('');
+  const showSpinner =
+    isProcessing || status.trim().endsWith('...');
   const [walls, setWalls] = useState<WallSurface[]>([]);
   const [groups, setGroups] = useState<WallGroup[]>([]);
   const [newGroupName, setNewGroupName] = useState('');
@@ -901,7 +903,7 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
               border: '1px solid #ccc'
             }}
           />
-          {isProcessing && (
+          {showSpinner && (
             <div className="processing-overlay">
               <div
                 className={`spinner${!sam ? ' spinner-large' : ''}`}


### PR DESCRIPTION
## Summary
- show spinner if status ends with `...` so it appears during model operations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683e823c09f8833382ca70a9a97b4d57