### PR TITLE
Fix tagline layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -27,6 +27,7 @@ h1 {
 .app-header {
   position: relative;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   margin-bottom: 1.5rem;
@@ -36,6 +37,8 @@ h1 {
 .nav-menu {
   position: absolute;
   left: 0;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .hamburger {


### PR DESCRIPTION
## Summary
- ensure header stacks tagline under title
- vertically center menu in header

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683e853f0870833390ea9a7b2f09e93c