### PR TITLE
Fix DOM check for main entry

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+const container = typeof document !== 'undefined'
+  ? document.getElementById('root')
+  : null
+
+if (container) {
+  createRoot(container).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  )
+}


### PR DESCRIPTION
## Summary
- avoid reference error when `document` is not defined

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_683e846de59c833385d4a0f19a573d12