### PR TITLE
Fix overlay for SAM decoder status

### DIFF
--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -96,8 +96,11 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
   const [sam, setSam] = useState<SAM2 | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [status, setStatus] = useState<string>('');
+  const trimmedStatus = status.trim();
   const showSpinner =
-    isProcessing || status.trim().endsWith('...');
+    isProcessing ||
+    (trimmedStatus.endsWith('...') &&
+      trimmedStatus !== 'Processing decoder output...');
   const [walls, setWalls] = useState<WallSurface[]>([]);
   const [groups, setGroups] = useState<WallGroup[]>([]);
   const [newGroupName, setNewGroupName] = useState('');


### PR DESCRIPTION
## Summary
- avoid spinner overlay when SAM reports `Processing decoder output...`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683e889868a4833399141731ba827aef