### PR TITLE
Refactor ImageCanvas into modules

### DIFF
--- a/src/components/GroupsSidebar.tsx
+++ b/src/components/GroupsSidebar.tsx
@@ -1,7 +1,7 @@
 import ColorPicker from './ColorPicker';
 import { PlusIcon, TrashIcon } from './Icons';
-import { WallGroup, WallSurface } from '../types/wall';
-import { Dispatch, SetStateAction } from 'react';
+import type { WallGroup, WallSurface } from '../types/wall';
+import type { Dispatch, SetStateAction } from 'react';
 
 interface GroupsSidebarProps {
   groups: WallGroup[];

--- a/src/components/GroupsSidebar.tsx
+++ b/src/components/GroupsSidebar.tsx
@@ -1,0 +1,173 @@
+import ColorPicker from './ColorPicker';
+import { PlusIcon, TrashIcon } from './Icons';
+import { WallGroup, WallSurface } from '../types/wall';
+import { Dispatch, SetStateAction } from 'react';
+
+interface GroupsSidebarProps {
+  groups: WallGroup[];
+  walls: WallSurface[];
+  newGroupName: string;
+  editingNames: Record<string, string>;
+  editingGroupId: string | null;
+  setNewGroupName: Dispatch<SetStateAction<string>>;
+  setEditingGroupId: Dispatch<SetStateAction<string | null>>;
+  addGroup: () => void;
+  handleGroupNameChange: (groupId: string, name: string) => void;
+  commitGroupName: (groupId: string) => void;
+  allowDrop: (e: React.DragEvent) => void;
+  handleDrop: (e: React.DragEvent<HTMLElement>, groupId: string | null) => void;
+  handleDragStart: (e: React.DragEvent<HTMLLIElement>, wallId: string) => void;
+  toggleWall: (id: string) => void;
+  removeWall: (wallId: string) => void;
+  previewGroupColor: (groupId: string, color: string) => void;
+  commitGroupColor: (groupId: string, color: string) => void;
+}
+
+export default function GroupsSidebar({
+  groups,
+  walls,
+  newGroupName,
+  editingNames,
+  editingGroupId,
+  setNewGroupName,
+  setEditingGroupId,
+  addGroup,
+  handleGroupNameChange,
+  commitGroupName,
+  allowDrop,
+  handleDrop,
+  handleDragStart,
+  toggleWall,
+  removeWall,
+  previewGroupColor,
+  commitGroupColor
+}: GroupsSidebarProps) {
+  return (
+    <>
+      <h2>Groups</h2>
+      <p className="instructions">
+        Drag surfaces here to organize them. Edit the names below and use the
+        color picker to set a group's color.
+      </p>
+      <h3>Add Group</h3>
+      <div className="add-group-row">
+        <input
+          type="text"
+          className="group-name-input"
+          placeholder="Enter group name"
+          value={newGroupName}
+          onChange={e => setNewGroupName(e.target.value)}
+        />
+        <button className="add-group" onClick={addGroup} title="Add group">
+          <PlusIcon />
+          <span>Add</span>
+        </button>
+      </div>
+      {groups.map(g => (
+        <div key={g.id} className="group-section">
+          <div className="group-header">
+            {editingGroupId === g.id ? (
+              <input
+                type="text"
+                className="group-name-input"
+                value={editingNames[g.id] ?? g.name}
+                autoFocus
+                onChange={e => handleGroupNameChange(g.id, e.target.value)}
+                onBlur={() => commitGroupName(g.id)}
+                onKeyDown={e =>
+                  e.key === 'Enter' &&
+                  (e.currentTarget as HTMLInputElement).blur()}
+              />
+            ) : (
+              <span
+                className="group-name-display"
+                onClick={() => setEditingGroupId(g.id)}
+              >
+                {g.name}
+              </span>
+            )}
+            <label className="color-picker-label">
+              Group color
+              <ColorPicker
+                value={g.color}
+                onChange={c => previewGroupColor(g.id, c)}
+                onChangeComplete={c => commitGroupColor(g.id, c)}
+              />
+            </label>
+          </div>
+          <ul
+            className="group-surfaces"
+            onDragOver={allowDrop}
+            onDrop={e => handleDrop(e, g.id)}
+          >
+            {walls.filter(w => w.groupId === g.id).length === 0 ? (
+              <li
+                className="drop-placeholder"
+                onDragOver={allowDrop}
+                onDrop={e => handleDrop(e, g.id)}
+              >
+                Drop surfaces here
+              </li>
+            ) : (
+              walls
+                .filter(w => w.groupId === g.id)
+                .map(w => (
+                  <li
+                    key={w.id}
+                    className="draggable"
+                    draggable
+                    onDragStart={e => handleDragStart(e, w.id)}
+                    onDragOver={allowDrop}
+                    onDrop={e => handleDrop(e, g.id)}
+                  >
+                    <label>
+                      <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
+                    </label>
+                    <button
+                      className="remove-btn"
+                      title="Delete surface"
+                      onClick={() => removeWall(w.id)}
+                    >
+                      <TrashIcon />
+                    </button>
+                  </li>
+                ))
+            )}
+          </ul>
+        </div>
+      ))}
+      {walls.filter(w => !w.groupId).length > 0 && (
+        <div className="group-section">
+          <div className="group-header"><span>Other</span></div>
+          <ul
+            className="group-surfaces"
+            onDragOver={allowDrop}
+            onDrop={e => handleDrop(e, null)}
+          >
+            {walls.filter(w => !w.groupId).map(w => (
+              <li
+                key={w.id}
+                className="draggable"
+                draggable
+                onDragStart={e => handleDragStart(e, w.id)}
+                onDragOver={allowDrop}
+                onDrop={e => handleDrop(e, null)}
+              >
+                <label>
+                  <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
+                </label>
+                <button
+                  className="remove-btn"
+                  title="Delete surface"
+                  onClick={() => removeWall(w.id)}
+                >
+                  <TrashIcon />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -19,7 +19,7 @@ import {
 } from '../lib/imageUtils';
 
 import GroupsSidebar from './GroupsSidebar';
-import { WallGroup, WallSurface } from '../types/wall';
+import type { WallGroup, WallSurface } from '../types/wall';
 
 import { type WhiteBalance } from './WhiteBalanceControls';
 
@@ -39,19 +39,7 @@ interface HistoryState {
 }
 
 
-interface WallSurface {
-  id: string;
-  pixels: Uint32Array;
-  color: string;
-  enabled: boolean;
-  groupId: string | null;
-}
 
-interface WallGroup {
-  id: string;
-  name: string;
-  color: string;
-}
 
 
 export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lighting, algorithm, sidebarContainer }: ImageCanvasProps) {

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -1,62 +1,28 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import ColorPicker from './ColorPicker';
-import { UndoIcon, RedoIcon, ResetIcon, TrashIcon, PlusIcon } from './Icons';
+import { UndoIcon, RedoIcon, ResetIcon } from './Icons';
 import { SAM2 } from '../lib/sam';
 import { AVAILABLE_MODELS, getModelFiles } from '../lib/sam/model-loader';
 import {
   srgbToLinear,
-  linearToSrgb,
   linearRgbToLab,
-  labToLinearRgb,
-  hexToLab,
   boxBlurFloat
 } from '../lib/color';
 import { NIIDNet, applyReflectanceColor } from '../lib/intrinsic';
 
+import {
+  applyWhiteBalance,
+  applyLighting,
+  scaleImageData,
+  maskToIndices,
+  applyRetinexRecolor
+} from '../lib/imageUtils';
+
+import GroupsSidebar from './GroupsSidebar';
+import { WallGroup, WallSurface } from '../types/wall';
+
 import { type WhiteBalance } from './WhiteBalanceControls';
 
-interface LightingPreset {
-  r: number;
-  g: number;
-  b: number;
-  brightness: number;
-}
-
-const LIGHTING_SETTINGS: Record<string, LightingPreset> = {
-  normal: { r: 1, g: 1, b: 1, brightness: 1 },
-  morning: { r: 1.1, g: 1.05, b: 0.95, brightness: 1.1 },
-  afternoon: { r: 1.05, g: 1.05, b: 1.1, brightness: 1 },
-  evening: { r: 1.1, g: 0.9, b: 0.8, brightness: 1 },
-  // Night mode simulates indoor LED lighting rather than moonlight
-  night: { r: 0.9, g: 0.95, b: 1.1, brightness: 0.8 },
-  cloudy: { r: 0.95, g: 1, b: 1.1, brightness: 0.95 }
-};
-
-function applyWhiteBalance(image: ImageData, wb: WhiteBalance): ImageData {
-  const out = new Uint8ClampedArray(image.data.length);
-  for (let i = 0; i < image.data.length; i += 4) {
-    out[i] = Math.min(255, image.data[i] * wb.r);
-    out[i + 1] = Math.min(255, image.data[i + 1] * wb.g);
-    out[i + 2] = Math.min(255, image.data[i + 2] * wb.b);
-    out[i + 3] = image.data[i + 3];
-  }
-  return new ImageData(out, image.width, image.height);
-}
-
-function applyLighting(ctx: CanvasRenderingContext2D, width: number, height: number, mode: string) {
-  const preset = LIGHTING_SETTINGS[mode];
-  if (!preset || mode === 'normal') return;
-  const img = ctx.getImageData(0, 0, width, height);
-  const { r, g, b, brightness } = preset;
-  const data = img.data;
-  for (let i = 0; i < data.length; i += 4) {
-    data[i] = Math.min(255, data[i] * r * brightness);
-    data[i + 1] = Math.min(255, data[i + 1] * g * brightness);
-    data[i + 2] = Math.min(255, data[i + 2] * b * brightness);
-  }
-  ctx.putImageData(img, 0, 0);
-}
 
 interface ImageCanvasProps {
   imageUrl: string;
@@ -426,8 +392,8 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
             indices,
             selectedColor
           );
-        } else {
-          applyRetinexRecolor(updated, indices, selectedColor);
+        } else if (retinexRef.current) {
+          applyRetinexRecolor(updated, indices, selectedColor, retinexRef.current);
         }
         setBaseImageData(updated);
         ctx.putImageData(updated, 0, 0);
@@ -455,97 +421,6 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
     }
   };
 
-  const scaleImageData = (source: ImageData, targetWidth: number, targetHeight: number): ImageData => {
-    if (source.width === targetWidth && source.height === targetHeight) {
-      return source;
-    }
-    const canvas = document.createElement('canvas');
-    canvas.width = source.width;
-    canvas.height = source.height;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) throw new Error('Failed to get canvas context');
-
-    // Draw source image data
-    ctx.putImageData(source, 0, 0);
-
-    // Create a temporary canvas for scaling
-    const tempCanvas = document.createElement('canvas');
-    tempCanvas.width = targetWidth;
-    tempCanvas.height = targetHeight;
-    const tempCtx = tempCanvas.getContext('2d');
-    if (!tempCtx) throw new Error('Failed to get temp canvas context');
-
-    // Disable smoothing for crisp mask edges
-    tempCtx.imageSmoothingEnabled = false;
-
-    // Scale the image
-    tempCtx.drawImage(canvas, 0, 0, targetWidth, targetHeight);
-    return tempCtx.getImageData(0, 0, targetWidth, targetHeight);
-  };
-
-  const maskToIndices = (mask: ImageData): Uint32Array => {
-    const { width, height, data } = mask;
-    const pixels: number[] = [];
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        const i = (y * width + x) * 4;
-        if (data[i] > 0) {
-          pixels.push(y * width + x);
-        }
-      }
-    }
-    return new Uint32Array(pixels);
-  };
-
-  const applyRetinexRecolor = (baseData: ImageData, indices: Uint32Array, colorHex: string) => {
-    const pre = retinexRef.current;
-    if (!pre) return;
-
-    const data = baseData.data;
-
-    const { L, A, B, gray, shade } = pre;
-
-    let sumL = 0;
-    let sumA = 0;
-    let sumB = 0;
-    let sumGray = 0;
-    const count = indices.length;
-
-    for (let k = 0; k < indices.length; k++) {
-      const i = indices[k];
-      sumL += L[i];
-      sumA += A[i];
-      sumB += B[i];
-      sumGray += gray[i];
-    }
-
-    if (count === 0) return;
-    const meanL = sumL / count;
-    const meanA = sumA / count;
-    const meanB = sumB / count;
-    const meanGray = sumGray / count;
-
-    const [Lt, at, bt] = hexToLab(colorHex);
-
-    for (let k = 0; k < indices.length; k++) {
-      const i = indices[k];
-      const p = i * 4;
-      const chromaScale = Math.min(Math.max(gray[i] / meanGray, 0.4), 1.0);
-      const a = at + (A[i] - meanA) * chromaScale;
-      const b = bt + (B[i] - meanB) * chromaScale;
-      const rawScale = meanL > 0 ? Lt / meanL : 1;
-      const lightnessScale = Math.min(rawScale, 5);
-      const Lval = Math.min(Math.max(L[i] * lightnessScale, 0), 100);
-      const [rLin, gLin, bLin] = labToLinearRgb(Lval, a, b);
-      const r = linearToSrgb(rLin * shade[i]);
-      const g = linearToSrgb(gLin * shade[i]);
-      const bb = linearToSrgb(bLin * shade[i]);
-      data[p] = r;
-      data[p + 1] = g;
-      data[p + 2] = bb;
-    }
-
-  };
 
   const recolorWall = (wall: WallSurface, newColor: string) => {
     if (!baseImageData) return;
@@ -561,8 +436,8 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
         wall.pixels,
         newColor
       );
-    } else {
-      applyRetinexRecolor(updated, wall.pixels, newColor);
+    } else if (retinexRef.current) {
+      applyRetinexRecolor(updated, wall.pixels, newColor, retinexRef.current);
     }
     setBaseImageData(updated);
     wall.color = newColor;
@@ -599,8 +474,8 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
           wall.pixels,
           wall.color
         );
-      } else {
-        applyRetinexRecolor(base, wall.pixels, wall.color);
+      } else if (retinexRef.current) {
+        applyRetinexRecolor(base, wall.pixels, wall.color, retinexRef.current);
       }
     }
     setBaseImageData(base);
@@ -814,134 +689,6 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
     applyLighting(ctx, canvas.width, canvas.height, lighting);
   }, [lighting, baseImageData]);
 
-  const groupsSidebar = (
-    <>
-      <h2>Groups</h2>
-      <p className="instructions">
-        Drag surfaces here to organize them. Edit the names below and use the
-        color picker to set a group's color.
-      </p>
-      <h3>Add Group</h3>
-      <div className="add-group-row">
-        <input
-          type="text"
-          className="group-name-input"
-          placeholder="Enter group name"
-          value={newGroupName}
-          onChange={e => setNewGroupName(e.target.value)}
-        />
-        <button className="add-group" onClick={addGroup} title="Add group">
-          <PlusIcon />
-          <span>Add</span>
-        </button>
-      </div>
-      {groups.map(g => (
-        <div key={g.id} className="group-section">
-          <div className="group-header">
-            {editingGroupId === g.id ? (
-              <input
-                type="text"
-                className="group-name-input"
-                value={editingNames[g.id] ?? g.name}
-                autoFocus
-                onChange={e => handleGroupNameChange(g.id, e.target.value)}
-                onBlur={() => commitGroupName(g.id)}
-                onKeyDown={e =>
-                  e.key === 'Enter' &&
-                  (e.currentTarget as HTMLInputElement).blur()}
-              />
-            ) : (
-              <span
-                className="group-name-display"
-                onClick={() => setEditingGroupId(g.id)}
-              >
-                {g.name}
-              </span>
-            )}
-            <label className="color-picker-label">
-              Group color
-              <ColorPicker
-                value={g.color}
-                onChange={c => previewGroupColor(g.id, c)}
-                onChangeComplete={c => commitGroupColor(g.id, c)}
-              />
-            </label>
-          </div>
-          <ul
-            className="group-surfaces"
-            onDragOver={allowDrop}
-            onDrop={e => handleDrop(e, g.id)}
-          >
-            {walls.filter(w => w.groupId === g.id).length === 0 ? (
-              <li
-                className="drop-placeholder"
-                onDragOver={allowDrop}
-                onDrop={e => handleDrop(e, g.id)}
-              >
-                Drop surfaces here
-              </li>
-            ) : (
-              walls
-                .filter(w => w.groupId === g.id)
-                .map(w => (
-              <li
-                key={w.id}
-                className="draggable"
-                draggable
-                onDragStart={e => handleDragStart(e, w.id)}
-                onDragOver={allowDrop}
-                onDrop={e => handleDrop(e, g.id)}
-              >
-                <label>
-                  <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
-                </label>
-                <button
-                  className="remove-btn"
-                  title="Delete surface"
-                  onClick={() => removeWall(w.id)}
-                >
-                  <TrashIcon />
-                </button>
-              </li>
-                ))
-            )}
-          </ul>
-        </div>
-      ))}
-      {walls.filter(w => !w.groupId).length > 0 && (
-        <div className="group-section">
-          <div className="group-header"><span>Other</span></div>
-          <ul
-            className="group-surfaces"
-            onDragOver={allowDrop}
-            onDrop={e => handleDrop(e, null)}
-          >
-            {walls.filter(w => !w.groupId).map(w => (
-              <li
-                key={w.id}
-                className="draggable"
-                draggable
-                onDragStart={e => handleDragStart(e, w.id)}
-                onDragOver={allowDrop}
-                onDrop={e => handleDrop(e, null)}
-              >
-                <label>
-                  <input type="checkbox" checked={w.enabled} onChange={() => toggleWall(w.id)} /> {w.id}
-                </label>
-                <button
-                  className="remove-btn"
-                  title="Delete surface"
-                  onClick={() => removeWall(w.id)}
-                >
-                  <TrashIcon />
-                </button>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </>
-  );
 
   return (
     <div className="canvas-wrapper">
@@ -989,7 +736,29 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
         </div>
       </div>
       {!isProcessing && status && <div className="status-bar">{status}</div>}
-      {sidebarContainer && createPortal(groupsSidebar, sidebarContainer)}
+      {sidebarContainer &&
+        createPortal(
+          <GroupsSidebar
+            groups={groups}
+            walls={walls}
+            newGroupName={newGroupName}
+            editingNames={editingNames}
+            editingGroupId={editingGroupId}
+            setNewGroupName={setNewGroupName}
+            setEditingGroupId={setEditingGroupId}
+            addGroup={addGroup}
+            handleGroupNameChange={handleGroupNameChange}
+            commitGroupName={commitGroupName}
+            allowDrop={allowDrop}
+            handleDrop={handleDrop}
+            handleDragStart={handleDragStart}
+            toggleWall={toggleWall}
+            removeWall={removeWall}
+            previewGroupColor={previewGroupColor}
+            commitGroupColor={commitGroupColor}
+          />,
+          sidebarContainer
+        )}
     </div>
   );
 }

--- a/src/lib/imageUtils.ts
+++ b/src/lib/imageUtils.ts
@@ -1,0 +1,145 @@
+import { hexToLab, labToLinearRgb, linearToSrgb } from './color';
+import { type WhiteBalance } from '../components/WhiteBalanceControls';
+
+export interface LightingPreset {
+  r: number;
+  g: number;
+  b: number;
+  brightness: number;
+}
+
+export const LIGHTING_SETTINGS: Record<string, LightingPreset> = {
+  normal: { r: 1, g: 1, b: 1, brightness: 1 },
+  morning: { r: 1.1, g: 1.05, b: 0.95, brightness: 1.1 },
+  afternoon: { r: 1.05, g: 1.05, b: 1.1, brightness: 1 },
+  evening: { r: 1.1, g: 0.9, b: 0.8, brightness: 1 },
+  // Night mode simulates indoor LED lighting rather than moonlight
+  night: { r: 0.9, g: 0.95, b: 1.1, brightness: 0.8 },
+  cloudy: { r: 0.95, g: 1, b: 1.1, brightness: 0.95 }
+};
+
+export interface RetinexData {
+  L: Float32Array;
+  A: Float32Array;
+  B: Float32Array;
+  gray: Float32Array;
+  shade: Float32Array;
+}
+
+export function applyWhiteBalance(image: ImageData, wb: WhiteBalance): ImageData {
+  const out = new Uint8ClampedArray(image.data.length);
+  for (let i = 0; i < image.data.length; i += 4) {
+    out[i] = Math.min(255, image.data[i] * wb.r);
+    out[i + 1] = Math.min(255, image.data[i + 1] * wb.g);
+    out[i + 2] = Math.min(255, image.data[i + 2] * wb.b);
+    out[i + 3] = image.data[i + 3];
+  }
+  return new ImageData(out, image.width, image.height);
+}
+
+export function applyLighting(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  mode: string
+) {
+  const preset = LIGHTING_SETTINGS[mode];
+  if (!preset || mode === 'normal') return;
+  const img = ctx.getImageData(0, 0, width, height);
+  const { r, g, b, brightness } = preset;
+  const data = img.data;
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = Math.min(255, data[i] * r * brightness);
+    data[i + 1] = Math.min(255, data[i + 1] * g * brightness);
+    data[i + 2] = Math.min(255, data[i + 2] * b * brightness);
+  }
+  ctx.putImageData(img, 0, 0);
+}
+
+export function scaleImageData(
+  source: ImageData,
+  targetWidth: number,
+  targetHeight: number
+): ImageData {
+  if (source.width === targetWidth && source.height === targetHeight) {
+    return source;
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = source.width;
+  canvas.height = source.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Failed to get canvas context');
+
+  ctx.putImageData(source, 0, 0);
+
+  const tempCanvas = document.createElement('canvas');
+  tempCanvas.width = targetWidth;
+  tempCanvas.height = targetHeight;
+  const tempCtx = tempCanvas.getContext('2d');
+  if (!tempCtx) throw new Error('Failed to get temp canvas context');
+  tempCtx.imageSmoothingEnabled = false;
+  tempCtx.drawImage(canvas, 0, 0, targetWidth, targetHeight);
+  return tempCtx.getImageData(0, 0, targetWidth, targetHeight);
+}
+
+export function maskToIndices(mask: ImageData): Uint32Array {
+  const { width, height, data } = mask;
+  const pixels: number[] = [];
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      if (data[i] > 0) {
+        pixels.push(y * width + x);
+      }
+    }
+  }
+  return new Uint32Array(pixels);
+}
+
+export function applyRetinexRecolor(
+  baseData: ImageData,
+  indices: Uint32Array,
+  colorHex: string,
+  pre: RetinexData
+) {
+  const data = baseData.data;
+  const { L, A, B, gray, shade } = pre;
+  let sumL = 0;
+  let sumA = 0;
+  let sumB = 0;
+  let sumGray = 0;
+  const count = indices.length;
+  for (let k = 0; k < indices.length; k++) {
+    const i = indices[k];
+    sumL += L[i];
+    sumA += A[i];
+    sumB += B[i];
+    sumGray += gray[i];
+  }
+  if (count === 0) return;
+  const meanL = sumL / count;
+  const meanA = sumA / count;
+  const meanB = sumB / count;
+  const meanGray = sumGray / count;
+
+  const [Lt, at, bt] = hexToLab(colorHex);
+
+  for (let k = 0; k < indices.length; k++) {
+    const i = indices[k];
+    const p = i * 4;
+    const chromaScale = Math.min(Math.max(gray[i] / meanGray, 0.4), 1.0);
+    const a = at + (A[i] - meanA) * chromaScale;
+    const b = bt + (B[i] - meanB) * chromaScale;
+    const rawScale = meanL > 0 ? Lt / meanL : 1;
+    const lightnessScale = Math.min(rawScale, 5);
+    const Lval = Math.min(Math.max(L[i] * lightnessScale, 0), 100);
+    const [rLin, gLin, bLin] = labToLinearRgb(Lval, a, b);
+    const r = linearToSrgb(rLin * shade[i]);
+    const g = linearToSrgb(gLin * shade[i]);
+    const bb = linearToSrgb(bLin * shade[i]);
+    data[p] = r;
+    data[p + 1] = g;
+    data[p + 2] = bb;
+  }
+}
+

--- a/src/types/wall.ts
+++ b/src/types/wall.ts
@@ -1,0 +1,13 @@
+export interface WallSurface {
+  id: string;
+  pixels: Uint32Array;
+  color: string;
+  enabled: boolean;
+  groupId: string | null;
+}
+
+export interface WallGroup {
+  id: string;
+  name: string;
+  color: string;
+}


### PR DESCRIPTION
## Summary
- split large `ImageCanvas` helpers into `imageUtils.ts`
- create new `GroupsSidebar` component
- move wall-related types to `src/types`
- update `ImageCanvas` to use the new modules

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6840887b94ac8333b453462bc14eebdb