### PR TITLE
Add improved surface selection with SAM2

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -410,6 +410,10 @@ h2 {
   transition: background-color 0.2s;
 }
 
+.canvas-controls button.active {
+  background-color: var(--accent-hover);
+}
+
 .canvas-controls button:hover {
   background-color: var(--accent-hover);
 }
@@ -700,6 +704,27 @@ h2 {
   padding: 0.25rem 0;
   border-radius: 6px;
   pointer-events: none;
+}
+
+.candidate-controls {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  display: flex;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 4px;
+  border-radius: 6px;
+  z-index: 10;
+}
+
+.candidate-controls button {
+  padding: 2px 6px;
+  border: none;
+  border-radius: 4px;
+  background: var(--accent-color);
+  color: #fff;
+  cursor: pointer;
 }
 
 .spinner {

--- a/src/App.css
+++ b/src/App.css
@@ -711,11 +711,23 @@ h2 {
   bottom: 8px;
   left: 8px;
   display: flex;
+  flex-direction: column;
   gap: 4px;
   background: rgba(255, 255, 255, 0.8);
   padding: 4px;
   border-radius: 6px;
   z-index: 10;
+}
+
+.candidate-controls .button-row {
+  display: flex;
+  gap: 4px;
+}
+
+.candidate-controls .instructions {
+  margin: 0;
+  font-size: 0.8rem;
+  font-style: italic;
 }
 
 .candidate-controls button {

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -53,7 +53,12 @@ export default function ImageCanvas({ imageUrl, selectedColor, whiteBalance, lig
   const [niid, setNiid] = useState<NIIDNet | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [status, setStatus] = useState<string>('');
-  const showSpinner = isProcessing;
+  const trimmedStatus = status.trim();
+  const showSpinner =
+    isProcessing ||
+    (trimmedStatus.endsWith('...') &&
+      trimmedStatus !== 'Processing decoder output...' &&
+      trimmedStatus !== 'Building mask...');
   const [walls, setWalls] = useState<WallSurface[]>([]);
   const [groups, setGroups] = useState<WallGroup[]>([]);
   const [newGroupName, setNewGroupName] = useState('');

--- a/src/pages/DesignPage.tsx
+++ b/src/pages/DesignPage.tsx
@@ -73,7 +73,7 @@ export default function DesignPage() {
             onChange={setSelectedColor}
           />
           <p className="instructions">
-            Hover to preview surfaces. Click to add points; hold <strong>Alt</strong> for negatives. Toggle <strong>Box</strong> (or press <strong>B</strong>) to draw a rectangle. Use the arrows under the image to choose a mask then Apply.
+            Hover to preview surfaces. Click to add points; hold <strong>Alt</strong> for negatives. Toggle <strong>Box</strong> (or press <strong>B</strong>) then drag and release to draw a rectangle. Use the arrows under the image to choose a mask then Apply.
           </p>
         </div>
         <div className="white-balance-section panel-section">

--- a/src/pages/DesignPage.tsx
+++ b/src/pages/DesignPage.tsx
@@ -73,7 +73,7 @@ export default function DesignPage() {
             onChange={setSelectedColor}
           />
           <p className="instructions">
-            Hover over the image to highlight surfaces. Click to apply the color.
+            Hover to preview surfaces. Click to add points; hold <strong>Alt</strong> for negatives. Toggle <strong>Box</strong> (or press <strong>B</strong>) to draw a rectangle. Use the arrows under the image to choose a mask then Apply.
           </p>
         </div>
         <div className="white-balance-section panel-section">


### PR DESCRIPTION
## Summary
- support generating multiple mask candidates with `SAM2.generateMasks`
- overhaul `ImageCanvas` to allow multi-point input and candidate cycling
- add candidate selection controls and box mode button
- update styles for new controls

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841403f6c6c833390ef670cff3ada26